### PR TITLE
fixed issue for connection to iSCSI protal 

### DIFF
--- a/ansible/roles/iscsi/templates/tgtd.json.j2
+++ b/ansible/roles/iscsi/templates/tgtd.json.j2
@@ -1,4 +1,4 @@
 {
-    "command": "tgtd -d 1 -f --iscsi portal={{ api_interface_address }}:{{ iscsi_port }}",
+    "command": "tgtd -d 1 -f --iscsi portal=0.0.0.0:{{ iscsi_port }}",
     "config_files": []
 }


### PR DESCRIPTION
fixed issue for connection to iSCSI protal when using lvm as cinder backend