### PR TITLE
fix for horizon, failed to start on CentOS 7.4

### DIFF
--- a/ansible/roles/horizon/templates/horizon.conf.j2
+++ b/ansible/roles/horizon/templates/horizon.conf.j2
@@ -11,6 +11,7 @@ TraceEnable off
     WSGIScriptReloading On
     WSGIDaemonProcess horizon-http processes={{ openstack_service_workers }} threads=1 user=horizon group=horizon display-name=%{GROUP} python-path={{ python_path }}
     WSGIProcessGroup horizon-http
+    WSGIApplicationGroup %{GLOBAL}
     WSGIScriptAlias / {{ python_path }}/openstack_dashboard/wsgi/django.wsgi
     WSGIPassAuthorization On
 


### PR DESCRIPTION
When upgrading to CentOS/RHEL 7.4, horizon fails to start.
Bug reference:
bug https://access.redhat.com/solutions/3139791
https://bugzilla.redhat.com/show_bug.cgi?id=1478042
