### PR TITLE
Deploy of SAN storages configuration files implemented

### DIFF
--- a/ansible/roles/cinder/tasks/config.yml
+++ b/ansible/roles/cinder/tasks/config.yml
@@ -63,6 +63,19 @@
   notify:
     - Restart cinder-api container
 
+- name: Copying over storage configuration files
+  vars:
+    service: "{{ cinder_services['cinder-volume'] }}"
+  template:
+    src: "{{ node_custom_config }}/cinder/{{ item }}"
+    dest: "{{ node_config_directory }}/cinder-volume/{{ item }}"
+  register: cinder_confs
+  when:
+    - inventory_hostname in groups[service.group]
+    - service.enabled | bool
+    - storage_conf_files is defined
+  with_items: "{{ storage_conf_files }}"
+
 - name: Copying over cinder.conf
   vars:
     service_name: "{{ item.key }}"

--- a/ansible/roles/cinder/templates/cinder-volume.json.j2
+++ b/ansible/roles/cinder/templates/cinder-volume.json.j2
@@ -34,6 +34,16 @@
             "owner": "cinder",
             "perm": "0600"
         }{% endif %}
+        {% if storage_conf_files is defined %},
+        {% for conf_file in storage_conf_files %}
+        {
+            "source": "{{ container_config_directory }}/{{ conf_file }}",
+            "dest": "/etc/cinder/{{ conf_file }}",
+            "owner": "cinder",
+            "perm": "0600"
+        }{% if not loop.last %},{% endif %}
+        {% endfor %}
+        {% endif %}
     ],
     "permissions": [
         {

--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -431,3 +431,14 @@ tempest_floating_network_name:
 #xenserver_himn_ip:
 #xenserver_username:
 #xenserver_connect_protocol:
+
+#######################################
+# Cinder storage configuration files
+#######################################
+# The array define additional configuration files that's required to configure various storage backend.
+# It's required to configure most of the backends listed at https://www.openstack.org/marketplace/drivers/
+# The configuration files itself have to be placed at <node_custom_config>/cinder directory
+# The variable below must be a list(array)
+#storage_conf_files:
+#  - < configuration file 1 >
+#  - < configuration file N >


### PR DESCRIPTION
The patch was implemented during a production deployment where I need to configure cinder volume service to manage volumes on 2 SAN storages. As SAN storages drivers require additional configuration files which is not supported by kolla-ansible, I created the patch.

Tested with Queens branch.