### PR TITLE
Increase Grafana retries and delay

### DIFF
--- a/ansible/roles/grafana/tasks/post_config.yml
+++ b/ansible/roles/grafana/tasks/post_config.yml
@@ -5,8 +5,8 @@
     status_code: 200
   register: result
   until: result.get('status') == 200
-  retries: 10
-  delay: 2
+  retries: 15
+  delay: 3
   run_once: true
 
 - name: Enable grafana datasources


### PR DESCRIPTION
Grafana deployment often fails because it takes longer to get to a working state, so I suggest increasing the delay and retries a bit.