### PR TITLE
Update install.yml

### DIFF
--- a/ansible/roles/baremetal/tasks/install.yml
+++ b/ansible/roles/baremetal/tasks/install.yml
@@ -84,6 +84,7 @@
   pip:
     name: docker
     state: latest
+    extra_args:  --ignore-installed
     virtualenv: "{{ virtualenv is none | ternary(omit, virtualenv) }}"
     virtualenv_site_packages: "{{ virtualenv is none | ternary(omit, virtualenv_site_packages) }}"
   become: True


### PR DESCRIPTION
I kept running into an issue after upgrading to pip 10 (part of the openstack kolla project instructions found here https://docs.openstack.org/kolla-ansible/latest/user/quickstart.html) that the docker SDK couldn't get installed due to the error below.  So I added the extra args that doesn't care and ignores the installed packages.

Cannot uninstall 'requests'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.