### PR TITLE
Include task to execute "start_rgw_keystone.yml"

### DIFF
--- a/ansible/roles/ceph/tasks/reconfigure.yml
+++ b/ansible/roles/ceph/tasks/reconfigure.yml
@@ -212,3 +212,8 @@
   with_together:
     - "{{ ceph_rgw_container_envs.results }}"
     - "{{ ceph_rgw_check_results.results }}"
+    
+- include_tasks: start_rgw_keystone.yml
+  when:
+    - ceph_rgw_container_envs.results
+    - enable_ceph_rgw_keystone | bool


### PR DESCRIPTION
Missing include task to execute "start_rgw_keystone.yml" when "enable_ceph_rgw_keystone" is enabled in globals.yml