### PR TITLE
Workaround for empty list entry

### DIFF
--- a/ansible/roles/baremetal/defaults/main.yml
+++ b/ansible/roles/baremetal/defaults/main.yml
@@ -77,7 +77,7 @@ easy_install_available: >-
 debian_pkg_install:
  - "{{ docker_apt_package }}"
  - git
- - "{% if not easy_install_available %}python-pip{% endif %}"
+ - "{% if not easy_install_available %}python-pip{% else %}git{% endif %}"
  - python-setuptools
  - ntp
 


### PR DESCRIPTION
The "Install apt packages" step will fail because of empty list entry on Ubuntu < 18.04:

TASK [baremetal : Install apt packages] ***************************************************************************************************************************************************************************
ok: [localhost] => (item=docker-ce)
ok: [localhost] => (item=git)
failed: [localhost] (item=) => {"changed": false, "item": "", "msg": "No package matching '' is available"}
...