### PR TITLE
Compatibility fixes to stable/queens for Ubuntu 18.04

### DIFF
--- a/ansible/roles/baremetal/tasks/install.yml
+++ b/ansible/roles/baremetal/tasks/install.yml
@@ -57,6 +57,16 @@
   with_items: "{{ redhat_pkg_install }}"
   when: ansible_os_family == 'RedHat'
 
+- name: Ensure ansible user has Docker access
+  user:
+    name: "{{ hostvars[inventory_hostname]['ansible_user'] }}"
+    groups: docker
+    append: yes
+    system: yes
+    update_password: on_create
+  become: True
+  when: hostvars[inventory_hostname]['ansible_user'] != "" and hostvars[inventory_hostname]['ansible_user'] != "root"
+
 - name: Install virtualenv packages
   package:
     name: python-virtualenv
@@ -65,10 +75,11 @@
   when: virtualenv is not none
 
 - name: Install pip
-  easy_install:
-    name: pip
-    virtualenv: "{{ virtualenv is none | ternary(omit, virtualenv) }}"
-    virtualenv_site_packages: "{{ virtualenv is none | ternary(omit, virtualenv_site_packages) }}"
+  package:
+    name: python-pip
+    state: present
+    #    virtualenv: "{{ virtualenv is none | ternary(omit, virtualenv) }}"
+    #    virtualenv_site_packages: "{{ virtualenv is none | ternary(omit, virtualenv_site_packages) }}"
   become: True
 
 - name: Install latest pip in the virtualenv

--- a/ansible/roles/baremetal/tasks/pre-install.yml
+++ b/ansible/roles/baremetal/tasks/pre-install.yml
@@ -2,7 +2,7 @@
 # NOTE: raw install is required to support cloud images which do not have python installed
 - name: "Install python2 and python-simplejson"
   become: True
-  raw: "yum install -y python python-simplejson || (apt-get update && apt-get install -y python2.7 python-simplejson)"
+  raw: "( apt update && apt install -y python2.7 python-simplejson ) || (yum install -y python python-simplejson)"
 
 - name: Gather facts
   setup:
@@ -106,7 +106,7 @@
 
 - name: Install docker apt gpg key
   apt_key:
-    url: "{{ docker_apt_url }}/{{ docker_apt_key_file }}"
+    url: "{{ docker_apt_url }}/{{ansible_distribution | lower}}/{{ docker_apt_key_file }}"
     id: "{{ docker_apt_key_id }}"
     state: present
   become: True

--- a/ansible/roles/baremetal/templates/docker_apt_repo.j2
+++ b/ansible/roles/baremetal/templates/docker_apt_repo.j2
@@ -2,5 +2,5 @@
 deb {{ docker_apt_url }} ./
 {% else %}
 # main docker repo
-deb {{ docker_apt_url }}/repo {{ ansible_distribution | lower }}-{{ ansible_distribution_release | lower }} main
+deb {{ docker_apt_url }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release | lower }} stable
 {% endif %}

--- a/ansible/roles/neutron/tasks/precheck.yml
+++ b/ansible/roles/neutron/tasks/precheck.yml
@@ -31,7 +31,7 @@
   command: systemctl show docker
   register: result
   changed_when: false
-  failed_when: result.stdout.find('MountFlags=1048576') == -1
+  failed_when: result.stdout.find('MountFlags=shared') == -1
   when:
     - (inventory_hostname in groups['neutron-dhcp-agent']
        or inventory_hostname in groups['neutron-l3-agent']

--- a/tools/cleanup-host
+++ b/tools/cleanup-host
@@ -67,6 +67,8 @@ echo "Getting folders name..."
 for dir in $FOLDER_PATH*; do
     if [ "$dir" == "$FOLDER_PATH""passwords.yml" ] || \
        [ "$dir" == "$FOLDER_PATH""globals.yml" ] || \
+       [ "$dir" == "$FOLDER_PATH""multinode" ] || \
+       [ "$dir" == "$FOLDER_PATH""all-in-one" ] || \
        [ "$dir" == "$FOLDER_PATH""kolla-build.conf" ] || \
        [ "$dir" == "$FOLDER_PATH""config" ]; then
         echo "Skipping:" $dir

--- a/tools/setup_Debian.sh
+++ b/tools/setup_Debian.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+echo "We are running setup_Debian.sh on $(hostname)"
+
 set -o xtrace
 set -o errexit
 
@@ -14,7 +16,8 @@ function add_key {
         # hkp://pool.sks-keyservers.net intermittenly doesn't have the correct
         # keyring. p80 is what the docker script pulls from and what we should
         # use for reliability too
-        sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && break || :
+        #sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && break || :
+        wget -qO - http://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
         sleep 5
     done
 }
@@ -73,7 +76,8 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 . /etc/lsb-release
 
 # Setup Docker repo and add signing key
-echo "deb http://apt.dockerproject.org/repo ubuntu-${DISTRIB_CODENAME} main" | sudo tee /etc/apt/sources.list.d/docker.list
+echo "deb http://download.docker.com/linux/ubuntu ${DISTRIB_CODENAME} stable" | sudo tee /etc/apt/sources.list.d/docker.list
+#echo "deb http://apt.dockerproject.org/repo ubuntu-${DISTRIB_CODENAME} main" | sudo tee /etc/apt/sources.list.d/docker.list
 add_key
 sudo apt-get update
 sudo apt-get -y install --no-install-recommends docker-engine


### PR DESCRIPTION
When using the queens release on Ubuntu 18.04 hosts, we needed to fix a few bugs to make it work. Several of the problems were related to outdated/wrong package repository URLs and related signing keys for external software dependencies (e.g. Docker).