### PR TITLE
Fix manila multi network fail.

### DIFF
--- a/ansible/roles/manila/tasks/deploy.yml
+++ b/ansible/roles/manila/tasks/deploy.yml
@@ -6,13 +6,25 @@
   when: inventory_hostname in groups['manila-api']
 
 - include_tasks: config.yml
-  when: inventory_hostname in groups['manila-api'] or
-        inventory_hostname in groups['manila-data'] or
-        inventory_hostname in groups['manila-share'] or
-        inventory_hostname in groups['manila-scheduler']
+  when: inventory_hostname in groups['manila-api'][0] or
+        inventory_hostname in groups['manila-data'][0] or
+        inventory_hostname in groups['manila-share'][0] or
+        inventory_hostname in groups['manila-scheduler'][0]
 
 - include_tasks: bootstrap.yml
-  when: inventory_hostname in groups['manila-api']
+  when: inventory_hostname in groups['manila-api'][0]
+
+- name: Flush handlers
+  meta: flush_handlers
+
+- include_tasks: config.yml
+  when: inventory_hostname not in groups['manila-api'][0] or
+        inventory_hostname not in groups['manila-data'][0] or
+        inventory_hostname not in groups['manila-share'][0] or
+        inventory_hostname not in groups['manila-scheduler'][0]
+
+- include_tasks: bootstrap.yml
+  when: inventory_hostname not in groups['manila-api'][0]
 
 - name: Flush handlers
   meta: flush_handlers


### PR DESCRIPTION
Manila starts every manila-share container at the same time so each controller creates a new "Manila network" ending in a "ServiceInstanceException: Ambiguous service networks."

Reference:
https://opendev.org/openstack/manila/src/commit/9dfdc680ad9dcd7025e0e355c6e1d26359959030/manila/share/drivers/service_instance.py#L756