### PR TITLE
set delay_auth_decision whenever swift is used

### DIFF
--- a/ansible/roles/swift/defaults/main.yml
+++ b/ansible/roles/swift/defaults/main.yml
@@ -66,7 +66,7 @@ swift_devices_match_mode: "strict"
 swift_devices_name: "KOLLA_SWIFT_DATA"
 # For S3 API we need to defer the auth decision to allow s3api and s3token
 # middlewares to process requests using EC2 credentials.
-swift_delay_auth_decision: "{{ enable_swift_s3api | bool }}"
+swift_delay_auth_decision: "{{ enable_swift | bool }}"
 
 # Boolean, true if there is a dedicated replication network.
 swift_has_replication_network: "{{ swift_storage_interface != swift_replication_interface }}"


### PR DESCRIPTION
Does not just affect s3api - needs to be set True whenever swift is enabled. Otherwise horizon can not get the policies and unable to create a new container from the web ui.