### PR TITLE
cyborg: use root to copy cyborg-api-paste.ini

### DIFF
--- a/ansible/roles/cyborg/tasks/config.yml
+++ b/ansible/roles/cyborg/tasks/config.yml
@@ -91,6 +91,7 @@
       - "{{ node_custom_config }}/cyborg/cyborg-api-paste.ini"
     dest: "{{ node_config_directory }}/cyborg-api/api-paste.ini"
     mode: "0660"
+  become: true
   when:
     - inventory_hostname in groups['cyborg-api']
     - service.enabled | bool

--- a/ansible/roles/watcher/tasks/config.yml
+++ b/ansible/roles/watcher/tasks/config.yml
@@ -40,6 +40,7 @@
     src: "{{ item.key }}.json.j2"
     dest: "{{ node_config_directory }}/{{ item.key }}/config.json"
     mode: "0660"
+  become: true
   when:
     - inventory_hostname in groups[item.value.group]
     - item.value.enabled | bool
@@ -59,6 +60,7 @@
       - "{{ node_custom_config }}/watcher/{{ inventory_hostname }}/watcher.conf"
     dest: "{{ node_config_directory }}/{{ item.key }}/watcher.conf"
     mode: "0660"
+  become: true
   when:
     - inventory_hostname in groups[item.value.group]
     - item.value.enabled | bool
@@ -71,6 +73,7 @@
     src: "{{ watcher_policy_file_path }}"
     dest: "{{ node_config_directory }}/{{ item.key }}/{{ watcher_policy_file }}"
     mode: "0660"
+  become: true
   when:
     - watcher_policy_file is defined
     - inventory_hostname in groups[item.value.group]


### PR DESCRIPTION
This is a follow-up to https://bugs.launchpad.net/kolla-ansible/+bug/1874028.
The developer forgot to become root. Consequently, the following error occurs:

    fatal: [localhost]: FAILED! => {"msg": "Failed to get information on remote file (/etc/kolla/cyborg-api/api-paste.ini): Permission denied"}