### PR TITLE
Fixing permission denied error

### DIFF
--- a/ansible/roles/chrony/templates/chrony.json.j2
+++ b/ansible/roles/chrony/templates/chrony.json.j2
@@ -5,7 +5,7 @@
             "source": "{{ container_config_directory }}/chrony.conf",
             "dest": "/etc/chrony/chrony.conf",
             "owner": "chrony",
-            "perm": "0600"
+            "perm": "0644"
         }
     ],
     "permissions": [


### PR DESCRIPTION
This fixes the chronyd container on Ubuntu. Without it the chrony process will exit with a permission denied error.

```
++ cat /run_command
+ CMD='/usr/sbin/chronyd -d -f /etc/chrony/chrony.conf'
+ ARGS=
+ sudo kolla_copy_cacerts
+ [[ ! -n '' ]]
+ . kolla_extend_start
++ rm -f /var/run/chronyd.pid
++ CHRONY_LOG_DIR=/var/log/kolla/chrony
++ [[ ! -d /var/log/kolla/chrony ]]
+++ stat -c %a /var/log/kolla/chrony
++ [[ 2755 != \7\5\5 ]]
++ chmod 755 /var/log/kolla/chrony
+++ stat -c %U:%G /var/log/kolla/chrony
++ [[ chrony:kolla != \c\h\r\o\n\y\:\c\h\r\o\n\y ]]
++ chown chrony:chrony /var/log/kolla/chrony
Running command: '/usr/sbin/chronyd -d -f /etc/chrony/chrony.conf'
+ echo 'Running command: '\''/usr/sbin/chronyd -d -f /etc/chrony/chrony.conf'\'''
+ exec /usr/sbin/chronyd -d -f /etc/chrony/chrony.conf
2021-06-09T07:56:55Z chronyd version 3.5 starting (+CMDMON +NTP +REFCLOCK +RTC +PRIVDROP +SCFILTER +SIGND +ASYNCDNS +SECHASH +IPV6 -DEBUG)
2021-06-09T07:56:55Z Fatal error : Could not open configuration file /etc/chrony/chrony.conf : Permission denied
```