### PR TITLE
Use IPSEC AH

### DIFF
--- a/ansible/roles/loadbalancer/templates/keepalived/keepalived.conf.j2
+++ b/ansible/roles/loadbalancer/templates/keepalived/keepalived.conf.j2
@@ -37,7 +37,7 @@ vrrp_instance kolla_internal_vip_{{ keepalived_virtual_router_id }} {
     }
 {% endif %}
     authentication {
-        auth_type PASS
+        auth_type AH
         auth_pass {{ keepalived_password }}
     }
     track_script {


### PR DESCRIPTION
"Strong authentication: IPSEC-AH is used to protect our VRRP advertisements from spoofed and reply attacks."

Source: https://keepalived.readthedocs.io/en/latest/case_study_failover.html