### PR TITLE
Prometheus: use {{kolla_internal_fqdn}} while accessing the OpenStack Exporter

### DIFF
--- a/ansible/roles/prometheus/templates/prometheus.yml.j2
+++ b/ansible/roles/prometheus/templates/prometheus.yml.j2
@@ -107,7 +107,7 @@ scrape_configs:
     honor_labels: true
     static_configs:
       - targets:
-        - '{{ kolla_internal_vip_address | put_address_in_context('url') }}:{{ prometheus_openstack_exporter_port }}'
+        - '{{ kolla_internal_fqdn | put_address_in_context('url') }}:{{ prometheus_openstack_exporter_port }}'
 {% endif %}
 
 {% if enable_prometheus_elasticsearch_exporter | bool %}


### PR DESCRIPTION
When ``kolla_enable_tls_internal`` is enabled  and ``kolla_internal_fqdn`` is set to a custom domain, Prometheus fails to access the OpenStack Exporter  by using ``https://{{kolla_internal_vip_address}}/metrics`` because the certificate is issued for `{{kolla_internal_fqdn}}` and  it cannot be validated (`x509: certificate signed by unknown authority`)

Alternative solution:

```
tls_config:
      insecure_skip_verify: true
```
