### PR TITLE
README: link to the meetings page directly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ workflow <https://docs.openstack.org/infra/manual/developers.html>`__.
 -  File bugs, blueprints, track releases, etc on
    `Launchpad <https://launchpad.net/kolla-ansible>`__.
 -  Attend weekly
-   `meetings <https://wiki.openstack.org/wiki/Meetings/Kolla>`__.
+   `meetings <https://docs.openstack.org/kolla/latest/contributor/meeting.html>`__.
 -  Contribute `code <https://opendev.org/openstack/kolla-ansible>`__.
 
 Contributors


### PR DESCRIPTION
The link to the meetings page points to a redirection. Edit link to point directly to the current location.