### PR TITLE
Update multinode

### DIFF
--- a/ansible/inventory/multinode
+++ b/ansible/inventory/multinode
@@ -629,6 +629,9 @@ blazar
 blazar
 
 # Prometheus
+[prometheus-haproxy-exporter:children]
+control
+
 [prometheus-node-exporter:children]
 monitoring
 control


### PR DESCRIPTION
fixed error:

fatal: [ct1]: FAILED! => {"msg": "The conditional check 'inventory_hostname in groups[item.value.group]' failed. The error was: error while evaluating conditional (inventory_hostname in groups[item.value.group]): 'dict object' has no attribute 'prometheus-haproxy-exporter'\n\nThe error appears to be in '/usr/local/share/kolla-ansible/ansible/roles/prometheus/tasks/config.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Ensuring config directories exist\n  ^ here\n"}