### PR TITLE
Refactor external ceph

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1160,6 +1160,8 @@ horizon_public_endpoint: "{{ kolla_external_fqdn | kolla_url(public_protocol, ho
 # External Ceph - cephx auth enabled (this is the standard nowadays, defaults to yes)
 external_ceph_cephx_enabled: "yes"
 
+ceph_cluster: "ceph"
+
 # External Ceph pool names
 ceph_cinder_pool_name: "volumes"
 ceph_cinder_backup_pool_name: "backups"
@@ -1173,14 +1175,6 @@ ceph_glance_user: "glance"
 ceph_gnocchi_user: "gnocchi"
 ceph_manila_user: "manila"
 ceph_nova_user: "{{ ceph_cinder_user }}"
-
-# External Ceph keyrings
-ceph_cinder_keyring: "client.{{ ceph_cinder_user }}.keyring"
-ceph_cinder_backup_keyring: "client.{{ ceph_cinder_backup_user }}.keyring"
-ceph_glance_keyring: "client.{{ ceph_glance_user }}.keyring"
-ceph_gnocchi_keyring: "client.{{ ceph_gnocchi_user }}.keyring"
-ceph_manila_keyring: "client.{{ ceph_manila_user }}.keyring"
-ceph_nova_keyring: "{{ ceph_cinder_keyring }}"
 
 #####################
 # VMware support

--- a/ansible/roles/cinder/defaults/main.yml
+++ b/ansible/roles/cinder/defaults/main.yml
@@ -267,11 +267,13 @@ cinder_backend_pure_roce_name: "Pure-FlashArray-roce"
 
 cinder_ceph_backends:
   - name: "{{ cinder_backend_ceph_name }}"
-    cluster: "ceph"
+    cluster: "{{ ceph_cluster }}"
+    user: "{{ ceph_cinder_user }}"
+    pool: "{{ ceph_cinder_pool_name }}"
     enabled: "{{ cinder_backend_ceph | bool }}"
 
 cinder_backup_backend_ceph_name: "rbd-1"
-cinder_backup_ceph_backend: "{{ cinder_ceph_backends | selectattr('name', 'equalto', cinder_backup_backend_ceph_name) | list | first }}"
+cinder_backup_ceph_backend: "{{ cinder_ceph_backends | selectattr('name', 'equalto', cinder_backup_backend_ceph_name) | list | first | combine({'pool': ceph_cinder_backup_pool_name, 'user': ceph_cinder_backup_user }) }}"
 
 skip_cinder_backend_check: False
 

--- a/ansible/roles/cinder/tasks/external_ceph.yml
+++ b/ansible/roles/cinder/tasks/external_ceph.yml
@@ -43,7 +43,7 @@
 
 - name: Copy over Ceph keyring files for cinder-volume
   vars:
-    keyring: "{{ item.cluster }}.{{ ceph_cinder_keyring }}"
+    keyring: "{{ item.cluster }}.client.{{ item.user }}.keyring"
   template:
     src: "{{ node_custom_config }}/cinder/cinder-volume/{{ keyring }}"
     dest: "{{ node_config_directory }}/cinder-volume/ceph/{{ keyring }}"

--- a/ansible/roles/cinder/templates/cinder.conf.j2
+++ b/ansible/roles/cinder/templates/cinder.conf.j2
@@ -27,10 +27,10 @@ enabled_backends = {{ cinder_enabled_backends|map(attribute='name')|join(',') }}
 {% if service_name == "cinder-backup" and enable_cinder_backup | bool %}
 {% if cinder_backup_driver == "ceph" %}
 backup_driver = cinder.backup.drivers.ceph.CephBackupDriver
-backup_ceph_conf = /etc/ceph/{{ cinder_backup_ceph_backend.cluster }}.conf
-backup_ceph_user = {{ ceph_cinder_backup_user }}
+backup_ceph_conf = /etc/ceph/{{ cinder_backup_ceph_backend['cluster'] }}.conf
+backup_ceph_user = {{ cinder_backup_ceph_backend['user'] }}
 backup_ceph_chunk_size = 134217728
-backup_ceph_pool = {{ ceph_cinder_backup_pool_name }}
+backup_ceph_pool = {{ cinder_backup_ceph_backend['pool'] }}
 backup_ceph_stripe_unit = 0
 backup_ceph_stripe_count = 0
 restore_discard_excess_bytes = true
@@ -150,12 +150,12 @@ target_protocol = iscsi
 [{{ backend.name }}]
 volume_driver = cinder.volume.drivers.rbd.RBDDriver
 volume_backend_name = {{ backend.name }}
-rbd_pool = {{ ceph_cinder_pool_name }}
+rbd_pool = {{ backend.pool }}
 rbd_ceph_conf = /etc/ceph/{{ backend.cluster }}.conf
 rados_connect_timeout = 5
-rbd_user = {{ ceph_cinder_user }}
+rbd_user = {{ backend.user }}
 rbd_cluster_name = {{ backend.cluster }}
-rbd_keyring_conf = /etc/ceph/{{ backend.cluster }}.{{ ceph_cinder_keyring }}
+rbd_keyring_conf = /etc/ceph/{{ backend.cluster }}.client.{{ backend.user }}.keyring
 rbd_secret_uuid = {{ cinder_rbd_secret_uuid }}
 report_discard_supported = True
 {% if backend.availability_zone is defined %}

--- a/ansible/roles/glance/defaults/main.yml
+++ b/ansible/roles/glance/defaults/main.yml
@@ -238,7 +238,9 @@ glance_backends:
 glance_ceph_backends:
   - name: "rbd"
     type: "rbd"
-    cluster: "ceph"
+    cluster: "{{ ceph_cluster }}"
+    pool: "{{ ceph_glance_pool_name }}"
+    user: "{{ ceph_glance_user }}"
     enabled: "{{ glance_backend_ceph | bool }}"
 
 glance_store_backends: "{{ glance_backends | selectattr('enabled', 'equalto', true) | list + glance_ceph_backends | selectattr('enabled', 'equalto', true) | list }}"

--- a/ansible/roles/glance/tasks/external_ceph.yml
+++ b/ansible/roles/glance/tasks/external_ceph.yml
@@ -27,9 +27,11 @@
     - Restart glance-api container
 
 - name: Copy over ceph Glance keyrings
+  vars:
+    keyring: "{{ item.cluster }}.client.{{ item.user }}.keyring"
   template:
-    src: "{{ node_custom_config }}/glance/{{ item.cluster }}.{{ ceph_glance_keyring }}"
-    dest: "{{ node_config_directory }}/glance-api/ceph/{{ item.cluster }}.{{ ceph_glance_keyring }}"
+    src: "{{ node_custom_config }}/glance/{{ keyring }}"
+    dest: "{{ node_config_directory }}/glance-api/ceph/{{ keyring }}"
     mode: "0660"
   become: true
   with_items: "{{ glance_ceph_backends }}"

--- a/ansible/roles/glance/templates/glance-api.conf.j2
+++ b/ansible/roles/glance/templates/glance-api.conf.j2
@@ -68,8 +68,8 @@ filesystem_store_datadir = /var/lib/glance/images/
 {% if glance_backend_ceph | bool %}
 {% for backend in glance_ceph_backends %}
 [{{ backend.name }}]
-rbd_store_user = {{ ceph_glance_user }}
-rbd_store_pool = {{ ceph_glance_pool_name }}
+rbd_store_user = {{ backend.user }}
+rbd_store_pool = {{ backend.pool }}
 rbd_store_ceph_conf = /etc/ceph/{{ backend.cluster }}.conf
 {% endfor %}
 {% endif %}

--- a/ansible/roles/gnocchi/defaults/main.yml
+++ b/ansible/roles/gnocchi/defaults/main.yml
@@ -192,5 +192,3 @@ gnocchi_ks_users:
     user: "{{ gnocchi_keystone_user }}"
     password: "{{ gnocchi_keystone_password }}"
     role: "admin"
-
-gnocchi_ceph_cluster: "ceph"

--- a/ansible/roles/gnocchi/tasks/external_ceph.yml
+++ b/ansible/roles/gnocchi/tasks/external_ceph.yml
@@ -15,9 +15,9 @@
 - name: Copy over ceph config for Gnocchi
   merge_configs:
     sources:
-      - "{{ node_custom_config }}/gnocchi/{{ gnocchi_ceph_cluster }}.conf"
-      - "{{ node_custom_config }}/gnocchi/{{ item.key }}/{{ gnocchi_ceph_cluster }}.conf"
-    dest: "{{ node_config_directory }}/{{ item.key }}/ceph/{{ gnocchi_ceph_cluster }}.conf"
+      - "{{ node_custom_config }}/gnocchi/{{ ceph_cluster }}.conf"
+      - "{{ node_custom_config }}/gnocchi/{{ item.key }}/{{ ceph_cluster }}.conf"
+    dest: "{{ node_config_directory }}/{{ item.key }}/ceph/{{ ceph_cluster }}.conf"
     mode: "0660"
   become: true
   when:
@@ -29,8 +29,8 @@
 
 - name: Copy over ceph Gnocchi keyrings
   template:
-    src: "{{ node_custom_config }}/gnocchi/{{ gnocchi_ceph_cluster }}.{{ ceph_gnocchi_keyring }}"
-    dest: "{{ node_config_directory }}/{{ item.key }}/ceph/{{ gnocchi_ceph_cluster }}.{{ ceph_gnocchi_keyring }}"
+    src: "{{ node_custom_config }}/gnocchi/{{ ceph_cluster }}.client.{{ ceph_gnocchi_user }}.keyring"
+    dest: "{{ node_config_directory }}/{{ item.key }}/ceph/{{ ceph_cluster }}.client.{{ ceph_gnocchi_user }}.keyring"
     mode: "0660"
   become: true
   with_dict: "{{ gnocchi_services }}"

--- a/ansible/roles/gnocchi/templates/gnocchi.conf.j2
+++ b/ansible/roles/gnocchi/templates/gnocchi.conf.j2
@@ -82,8 +82,8 @@ file_basepath = /var/lib/gnocchi
 driver = ceph
 ceph_pool = {{ ceph_gnocchi_pool_name }}
 ceph_username = {{ ceph_gnocchi_user }}
-ceph_keyring = /etc/ceph/{{ gnocchi_ceph_cluster }}.{{ ceph_gnocchi_keyring }}
-ceph_conffile = /etc/ceph/{{ gnocchi_ceph_cluster }}.conf
+ceph_keyring = /etc/ceph/{{ ceph_cluster }}.client.{{ ceph_gnocchi_user }}.keyring
+ceph_conffile = /etc/ceph/{{ ceph_cluster }}.conf
 {% elif gnocchi_backend_storage == 'swift' %}
 driver = swift
 swift_authurl = {{ keystone_internal_url }}

--- a/ansible/roles/manila/defaults/main.yml
+++ b/ansible/roles/manila/defaults/main.yml
@@ -238,14 +238,14 @@ manila_ceph_backends:
   - name: "cephfsnative1"
     share_name: "CEPHFS1"
     driver: "cephfsnative"
-    cluster: "ceph"
+    cluster: "{{ ceph_cluster }}"
     enabled: "{{ enable_manila_backend_cephfs_native | bool }}"
     protocols:
       - "CEPHFS"
   - name: "cephfsnfs1"
     share_name: "CEPHFSNFS1"
     driver: "cephfsnfs"
-    cluster: "ceph"
+    cluster: "{{ ceph_cluster }}"
     enabled: "{{ enable_manila_backend_cephfs_nfs | bool }}"
     protocols:
       - "NFS"

--- a/ansible/roles/manila/tasks/external_ceph.yml
+++ b/ansible/roles/manila/tasks/external_ceph.yml
@@ -30,8 +30,8 @@
 
 - name: Copy over ceph Manila keyrings
   template:
-    src: "{{ node_custom_config }}/manila/{{ item.cluster }}.{{ ceph_manila_keyring }}"
-    dest: "{{ node_config_directory }}/manila-share/ceph/{{ item.cluster }}.{{ ceph_manila_keyring }}"
+    src: "{{ node_custom_config }}/manila/{{ item.cluster }}.client.{{ ceph_manila_user }}.keyring"
+    dest: "{{ node_config_directory }}/manila-share/ceph/{{ item.cluster }}.client.{{ ceph_manila_user }}.keyring"
     mode: "0660"
   become: true
   with_items: "{{ manila_ceph_backends }}"

--- a/ansible/roles/nova-cell/defaults/main.yml
+++ b/ansible/roles/nova-cell/defaults/main.yml
@@ -85,6 +85,15 @@ nova_cell_config_validation:
 # qemu (1, 6, 0) or later. Set to "" to disable.
 nova_hw_disk_discard: "unmap"
 
+nova_cell_ceph_backend:
+  cluster: "{{ ceph_cluster }}"
+  vms:
+    user: "{{ ceph_nova_user }}"
+    pool: "{{ ceph_nova_pool_name }}"
+  volumes:
+    user: "{{ ceph_cinder_user }}"
+    pool: "{{ ceph_cinder_pool_name }}"
+
 ####################
 # Cells Options
 ####################
@@ -528,8 +537,6 @@ nova_notification_topics:
     enabled: "{{ designate_enable_notifications_sink | bool }}"
 
 nova_enabled_notification_topics: "{{ nova_notification_topics | selectattr('enabled', 'equalto', true) | list }}"
-
-nova_ceph_cluster: "ceph"
 
 ####################
 # VMware

--- a/ansible/roles/nova-cell/tasks/external_ceph.yml
+++ b/ansible/roles/nova-cell/tasks/external_ceph.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check nova keyring file
   vars:
-    keyring: "{{ nova_ceph_cluster }}.{{ ceph_nova_keyring }}"
+    keyring: "{{ nova_cell_ceph_backend['cluster'] }}.client.{{ nova_cell_ceph_backend['vms']['user'] }}.keyring"
     paths:
       - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ keyring }}"
       - "{{ node_custom_config }}/nova/{{ keyring }}"
@@ -16,7 +16,7 @@
 
 - name: Check cinder keyring file
   vars:
-    keyring: "{{ nova_ceph_cluster }}.{{ ceph_cinder_keyring }}"
+    keyring: "{{ nova_cell_ceph_backend['cluster'] }}.client.{{ nova_cell_ceph_backend['volumes']['user'] }}.keyring"
     paths:
       - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ keyring }}"
       - "{{ node_custom_config }}/nova/{{ keyring }}"
@@ -85,8 +85,8 @@
   vars:
     service: "{{ nova_cell_services[item] }}"
     paths:
-      - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ nova_ceph_cluster }}.conf"
-      - "{{ node_custom_config }}/nova/{{ nova_ceph_cluster }}.conf"
+      - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ nova_cell_ceph_backend['cluster'] }}.conf"
+      - "{{ node_custom_config }}/nova/{{ nova_cell_ceph_backend['cluster'] }}.conf"
   template:
     src: "{{ lookup('first_found', paths) }}"
     dest: "{{ node_config_directory }}/{{ item }}/"
@@ -108,8 +108,8 @@
     - name: Ensure /etc/ceph directory exists (host libvirt)
       vars:
         paths:
-          - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ nova_ceph_cluster }}.conf"
-          - "{{ node_custom_config }}/nova/{{ nova_ceph_cluster }}.conf"
+          - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ nova_cell_ceph_backend['cluster'] }}.conf"
+          - "{{ node_custom_config }}/nova/{{ nova_cell_ceph_backend['cluster'] }}.conf"
       file:
         path: "/etc/ceph/"
         state: "directory"
@@ -121,11 +121,11 @@
     - name: Copy over ceph.conf (host libvirt)
       vars:
         paths:
-          - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ nova_ceph_cluster }}.conf"
-          - "{{ node_custom_config }}/nova/{{ nova_ceph_cluster }}.conf"
+          - "{{ node_custom_config }}/nova/{{ inventory_hostname }}/{{ nova_cell_ceph_backend['cluster'] }}.conf"
+          - "{{ node_custom_config }}/nova/{{ nova_cell_ceph_backend['cluster'] }}.conf"
       template:
         src: "{{ lookup('first_found', paths) }}"
-        dest: "/etc/ceph/{{ nova_ceph_cluster }}.conf"
+        dest: "/etc/ceph/{{ nova_cell_ceph_backend['cluster'] }}.conf"
         owner: "root"
         group: "root"
         mode: "0644"
@@ -164,10 +164,10 @@
         - item.enabled | bool
       with_items:
         - uuid: "{{ rbd_secret_uuid }}"
-          name: "client.nova secret"
+          name: "client.{{ nova_cell_ceph_backend['vms']['user'] }} secret"
           enabled: "{{ nova_backend == 'rbd' }}"
         - uuid: "{{ cinder_rbd_secret_uuid }}"
-          name: "client.cinder secret"
+          name: "client.{{ nova_cell_ceph_backend['volumes']['user'] }} secret"
           enabled: "{{ cinder_backend_ceph }}"
       notify: "{{ libvirt_restart_handlers }}"
 

--- a/ansible/roles/nova-cell/templates/nova-compute.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-compute.json.j2
@@ -14,14 +14,14 @@
             "perm": "0600"
         }{% endif %}{% if nova_backend == "rbd" %},
         {
-            "source": "{{ container_config_directory }}/ceph.{{ ceph_nova_keyring }}",
-            "dest": "/etc/ceph/ceph.{{ ceph_nova_keyring }}",
+            "source": "{{ container_config_directory }}/{{ nova_cell_ceph_backend['cluster'] }}.client.{{ nova_cell_ceph_backend['vms']['user'] }}.keyring",
+            "dest": "/etc/ceph/{{ nova_cell_ceph_backend['cluster'] }}.client.{{ nova_cell_ceph_backend['vms']['user'] }}.keyring",
             "owner": "nova",
             "perm": "0600"
         },
         {
-            "source": "{{ container_config_directory }}/{{ nova_ceph_cluster }}.conf",
-            "dest": "/etc/ceph/{{ nova_ceph_cluster }}.conf",
+            "source": "{{ container_config_directory }}/{{ nova_cell_ceph_backend['cluster'] }}.conf",
+            "dest": "/etc/ceph/{{ nova_cell_ceph_backend['cluster'] }}.conf",
             "owner": "nova",
             "perm": "0600"
         }{% endif %}{% if nova_compute_virt_type == "vmware" and not vmware_vcenter_insecure | bool %},

--- a/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
+++ b/ansible/roles/nova-cell/templates/nova-libvirt.json.j2
@@ -51,8 +51,8 @@
             "merge": true
         }{% endif %}{% if nova_backend == "rbd" %},
         {
-            "source": "{{ container_config_directory }}/ceph.conf",
-            "dest": "/etc/ceph/ceph.conf",
+            "source": "{{ container_config_directory }}/{{ nova_cell_ceph_backend['cluster'] }}.conf",
+            "dest": "/etc/ceph/{{ nova_cell_ceph_backend['cluster'] }}.conf",
             "owner": "nova",
             "perm": "0600"
         }{% endif %}{% if libvirt_enable_sasl | bool %},

--- a/ansible/roles/nova-cell/templates/nova.conf.d/libvirt.conf.j2
+++ b/ansible/roles/nova-cell/templates/nova.conf.d/libvirt.conf.j2
@@ -9,9 +9,9 @@ live_migration_inbound_addr = "{{ migration_interface_address }}"
 {% endif %}
 {% if nova_backend == "rbd" %}
 images_type = rbd
-images_rbd_pool = {{ ceph_nova_pool_name }}
-images_rbd_ceph_conf = /etc/ceph/ceph.conf
-rbd_user = {{ ceph_nova_user }}
+images_rbd_pool = {{ nova_cell_ceph_backend['vms']['pool'] }}
+images_rbd_ceph_conf = /etc/ceph/{{ nova_cell_ceph_backend['cluster'] }}.conf
+rbd_user = {{ nova_cell_ceph_backend['vms']['user'] }}
 disk_cachemodes="network=writeback"
 {% if nova_hw_disk_discard != '' %}
 hw_disk_discard = {{ nova_hw_disk_discard }}

--- a/ansible/roles/zun/defaults/main.yml
+++ b/ansible/roles/zun/defaults/main.yml
@@ -244,5 +244,3 @@ zun_ks_users:
     user: "{{ zun_keystone_user }}"
     password: "{{ zun_keystone_password }}"
     role: "admin"
-
-zun_ceph_cluster: "ceph"

--- a/ansible/roles/zun/tasks/external_ceph.yml
+++ b/ansible/roles/zun/tasks/external_ceph.yml
@@ -1,7 +1,7 @@
 ---
 - name: Copying over ceph.conf for Zun
   copy:
-    src: "{{ node_custom_config }}/zun/zun-compute/{{ zun_ceph_cluster }}.conf"
+    src: "{{ node_custom_config }}/zun/zun-compute/{{ ceph_cluster }}.conf"
     dest: "{{ node_config_directory }}/zun-compute/"
     mode: "0660"
   become: true
@@ -10,7 +10,7 @@
 
 - name: Copy over Ceph keyring files for zun-compute
   copy:
-    src: "{{ node_custom_config }}/zun/zun-compute/{{ zun_ceph_cluster }}.{{ ceph_cinder_keyring }}"
+    src: "{{ node_custom_config }}/zun/zun-compute/{{ ceph_cluster }}.client.{{ ceph_cinder_user }}.keyring"
     dest: "{{ node_config_directory }}/zun-compute/"
     mode: "0660"
   become: true

--- a/ansible/roles/zun/templates/zun-compute.json.j2
+++ b/ansible/roles/zun/templates/zun-compute.json.j2
@@ -8,15 +8,15 @@
             "perm": "0600"
         },
         {
-            "source": "{{ container_config_directory }}/{{ zun_ceph_cluster }}.{{ ceph_cinder_keyring }}",
-            "dest": "/etc/ceph/{{ zun_ceph_cluster }}.{{ ceph_cinder_keyring }}",
+            "source": "{{ container_config_directory }}/{{ ceph_cluster }}.client.{{ ceph_cinder_user }}.keyring",
+            "dest": "/etc/ceph/{{ ceph_cluster }}.client.{{ ceph_cinder_user }}.keyring",
             "owner": "zun",
             "perm": "0600",
             "optional": {{ (not zun_configure_for_cinder_ceph | bool) | string | lower }}
         },
         {
-            "source": "{{ container_config_directory }}/{{ zun_ceph_cluster }}.conf",
-            "dest": "/etc/ceph/{{ zun_ceph_cluster }}.conf",
+            "source": "{{ container_config_directory }}/{{ ceph_cluster }}.conf",
+            "dest": "/etc/ceph/{{ ceph_cluster }}.conf",
             "owner": "zun",
             "perm": "0600",
             "optional": {{ (not zun_configure_for_cinder_ceph | bool) | string | lower }}

--- a/doc/source/user/operating-kolla.rst
+++ b/doc/source/user/operating-kolla.rst
@@ -75,8 +75,7 @@ Limitations and Recommendations
 .. note::
 
    If you have separate keys for nova and cinder, please be sure to set
-   ``ceph_nova_keyring: ceph.client.nova.keyring`` and ``ceph_nova_user: nova``
-   in ``/etc/kolla/globals.yml``
+   ``ceph_nova_user: nova`` in ``/etc/kolla/globals.yml``
 
 Ubuntu Jammy 22.04
 ------------------

--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -473,26 +473,20 @@ workaround_ansible_issue_8743: yes
 
 # Glance
 #ceph_glance_user: "glance"
-#ceph_glance_keyring: "client.{{ ceph_glance_user }}.keyring"
 #ceph_glance_pool_name: "images"
 # Cinder
 #ceph_cinder_user: "cinder"
-#ceph_cinder_keyring: "client.{{ ceph_cinder_user }}.keyring"
 #ceph_cinder_pool_name: "volumes"
 #ceph_cinder_backup_user: "cinder-backup"
-#ceph_cinder_backup_keyring: "client.{{ ceph_cinder_backup_user }}.keyring"
 #ceph_cinder_backup_pool_name: "backups"
 # Nova
-#ceph_nova_keyring: "{{ ceph_cinder_keyring }}"
 #ceph_nova_user: "{{ ceph_cinder_user }}"
 #ceph_nova_pool_name: "vms"
 # Gnocchi
 #ceph_gnocchi_user: "gnocchi"
-#ceph_gnocchi_keyring: "client.{{ ceph_gnocchi_user }}.keyring"
 #ceph_gnocchi_pool_name: "gnocchi"
 # Manila
 #ceph_manila_user: "manila"
-#ceph_manila_keyring: "client.{{ ceph_manila_user }}.keyring"
 
 #############################
 # Keystone - Identity Options


### PR DESCRIPTION
Kolla-ansible supports configuration
when multiple ceph clusters are used.

This patch only refactor kolla-ansible code.

This is also very handy when testing multiple ceph cluster with one ceph cluster but with different
pools/users/cluster names.

Change-Id: I2593b6df737b384f1a5fba22f69e851c575990b4