### PR TITLE
Change lookup of cinderkeyring nova-cell external_ceph

### DIFF
--- a/ansible/roles/nova-cell/tasks/external_ceph.yml
+++ b/ansible/roles/nova-cell/tasks/external_ceph.yml
@@ -41,7 +41,7 @@
 - name: Extract cinder key from file
   set_fact:
     cinder_cephx_raw_key:
-      "{{ lookup('file', cinder_cephx_keyring_file.stat.path) | regex_search('key\\s*=.*$', multiline=True) | regex_replace('key\\s*=\\s*(.*)\\s*', '\\1') }}"
+      "{{ lookup('template', cinder_cephx_keyring_file.stat.path) | regex_search('key\\s*=.*$', multiline=True) | regex_replace('key\\s*=\\s*(.*)\\s*', '\\1') }}"
   changed_when: false
   when:
     - cinder_backend_ceph | bool


### PR DESCRIPTION
We have the issue, that we  can't use different cinder keyrings per AZ as the libvirt secret is looked up from a file.
So if we use a variable in ceph.client.cinder.keyring, we get "None" as secretcontent.

Small change fixes it, and as it should not be an issue, lookup a file with the template module, the other way arround is one.