### PR TITLE
Correctly append --ask-vault-password as a single argument

### DIFF
--- a/kolla_ansible/ansible.py
+++ b/kolla_ansible/ansible.py
@@ -253,7 +253,7 @@ def build_args(parsed_args,
     for vault_pass_file in parsed_args.vault_password_file:
         args += ["--vault-password-file", vault_pass_file]
     if parsed_args.ask_vault_password:
-        args += "--ask-vault-password"
+        args += ["--ask-vault-password"]
     vars_files = _get_vars_files(
         os.path.abspath(parsed_args.kolla_config_path))
     for vars_file in vars_files:


### PR DESCRIPTION
Correctly append --ask-vault-password as a single argument

Related-Bug: #2106540

This fix should also be backported to stable/2024.2
