### PR TITLE
fix: octavia.conf.j2 jobboard_backend_hosts

### DIFF
--- a/ansible/roles/octavia/templates/octavia.conf.j2
+++ b/ansible/roles/octavia/templates/octavia.conf.j2
@@ -158,7 +158,6 @@ ca_certificates_file = {{ openstack_cacert }}
 {% if enable_octavia_jobboard | bool %}
 
 [task_flow]
-jobboard_backend_hosts = {% for host in groups['redis'] %}{{ 'api' | kolla_address(host) | put_address_in_context('url') }}{% if not loop.last %},{% endif %}{% endfor %}
 jobboard_backend_password = {{ redis_master_password }}
 jobboard_backend_port = {{ redis_sentinel_port }}
 jobboard_backend_username = default
@@ -167,4 +166,5 @@ jobboard_redis_backend_ssl_options = ssl:False
 jobboard_redis_sentinel = kolla
 jobboard_redis_sentinel_ssl_options = ssl:False
 persistence_connection = mysql+pymysql://{{ octavia_persistence_database_user }}:{{ octavia_persistence_database_password }}@{{ octavia_persistence_database_address }}/{{ octavia_persistence_database_name }}
+jobboard_backend_hosts = {% for host in groups['redis'] %}{{ 'api' | kolla_address(host) | put_address_in_context('url') }}{% if not loop.last %},{% endif %}{% endfor %}
 {% endif %}


### PR DESCRIPTION
I noticed that the jobboard_backend_hosts line in the template doesn't insert a newline after rendering. As a result, the jobboard_backend_password setting ends up on the same line, which breaks the config. As a workaround, I moved the jobboard_backend_hosts line to the end of the block for now.