### PR TITLE
[octavia] added missing 'enabled: true' attribute

### DIFF
--- a/etc/kolla/globals.yml
+++ b/etc/kolla/globals.yml
@@ -811,6 +811,7 @@ workaround_ansible_issue_8743: yes
 #octavia_amp_security_groups:
 #    mgmt-sec-grp:
 #      name: "lb-mgmt-sec-grp"
+#      enabled: true
 #      rules:
 #        - protocol: icmp
 #        - protocol: tcp


### PR DESCRIPTION
When deploying Octavia with the `octavia_amp_security_groups` option enabled using Kolla (tested with both versions 2025.1 and 2024.2), the following error occurs:

```
fatal: [HOST -> {{ groups['octavia-api'][0] }}]: FAILED! => {"msg": "The conditional check 'item.enabled | bool' failed. The error was: error while evaluating conditional (item.enabled | bool): 'dict object' has no attribute 'enabled'\n\nThe error appears to be in '/home/stack/openstack-deployment/venv/share/kolla-ansible/ansible/roles/octavia/tasks/prepare.yml': line 57, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Create security groups for octavia\n  ^ here\n"}
```

I resolved the issue by explicitly setting the default value `enabled: true`