### PR TITLE
Refactor enable_iscsid_for_cinder logic in main.yml

### DIFF
--- a/ansible/roles/iscsi/defaults/main.yml
+++ b/ansible/roles/iscsi/defaults/main.yml
@@ -67,8 +67,8 @@ iscsid_cinder_volume_group: >-
      'cinder-volume' }}
 enable_iscsid_for_cinder: >-
   {{ (inventory_hostname in groups['compute']
-      or inventory_hostname in groups[iscsid_cinder_backup_group] if enable_cinder_backend_lvm | bool
-      or inventory_hostname in groups[iscsid_cinder_volume_group] if enable_cinder_backend_lvm | bool)
+      or inventory_hostname in groups['cinder-backup']
+      or inventory_hostname in groups['cinder-volume'])
      and enable_cinder | bool
      and enable_cinder_backend_iscsi | bool }}
 enable_iscsid_for_ironic: >-


### PR DESCRIPTION
Due to wrong inventory group names (not present in multinode inventory file)  [iscsid_cinder_backup_group] and [iscsid_cinder_volume_group]  iscsid containers are not getting created which causes the volume creation to fail. 

After changing it to cinder-volume and cinder-backup, volume creation service get restored.

Tested inside my lab so creating PR.

Please review and approve